### PR TITLE
Home work sticky

### DIFF
--- a/src/Trip/DataAccess.test.ts
+++ b/src/Trip/DataAccess.test.ts
@@ -8,6 +8,7 @@ import { placesDetailedCache as Cache, tripsDetailedCache } from '../Cache';
 import { setEnvironment, setTripConflictHandler } from '../Settings';
 import * as TripApiTestData from '../TestData/TripApiResponses';
 import * as TripExpectedResults from '../TestData/TripExpectedResults';
+import * as User from '../User';
 import * as Xhr from '../Xhr';
 import { ApiResponse } from '../Xhr/ApiResponse';
 import * as Dao from './DataAccess';
@@ -25,6 +26,9 @@ describe('TripDataAccess', () => {
 
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
+		sandbox.stub(User, 'getUserSettings').returns(new Promise<User.UserSettings>((resolve) => {
+			resolve({homePlaceId: null, workPlaceId: null});
+		}));
 		clock = sinon.useFakeTimers((new Date()).getTime());
 		Cache.reset();
 	});

--- a/src/Trip/DataAccess.ts
+++ b/src/Trip/DataAccess.ts
@@ -4,6 +4,7 @@ import { stringify } from 'query-string';
 
 import { tripsDetailedCache as tripsDetailedCache } from '../Cache';
 import { getTripConflictHandler } from '../Settings';
+import { getUserSettings } from '../User';
 import { dateToW3CString } from '../Util';
 import { ApiResponse, get, post, put } from '../Xhr';
 import {
@@ -43,7 +44,7 @@ export async function getTripDetailed(id: string): Promise<Trip> {
 		result = fromCache;
 	}
 
-	return mapTripDetailedApiResponseToTrip(result);
+	return mapTripDetailedApiResponseToTrip(result, await getUserSettings());
 }
 
 export async function createTrip(tripRequest: TripCreateRequest): Promise<Trip> {
@@ -53,7 +54,7 @@ export async function createTrip(tripRequest: TripCreateRequest): Promise<Trip> 
 	}
 	const tripData = apiResponse.data.trip;
 	await tripsDetailedCache.set(tripData.id, tripData);
-	return mapTripDetailedApiResponseToTrip(tripData);
+	return mapTripDetailedApiResponseToTrip(tripData, await getUserSettings());
 }
 
 export async function updateTrip(tripToBeUpdated: Trip): Promise<Trip> {

--- a/src/Trip/Manipulator.test.ts
+++ b/src/Trip/Manipulator.test.ts
@@ -34,7 +34,7 @@ describe('TripManipulator', () => {
 				} as Day);
 			}
 
-			return chai.expect(Manipulator.addDay(inputTrip)).to.deep.equal(expectedTrip);
+			return chai.expect(Manipulator.addDay(inputTrip, null)).to.deep.equal(expectedTrip);
 		});
 
 		it('should add day to trip and add sticky place by default to new day', () => {
@@ -46,7 +46,7 @@ describe('TripManipulator', () => {
 					place.categories = ['sleeping'];
 				}
 			}
-			const returnedTrip = Manipulator.addDay(inputTrip);
+			const returnedTrip = Manipulator.addDay(inputTrip, null);
 
 			return chai.expect(returnedTrip.days && returnedTrip.days[1].itinerary[0].placeId)
 				.to.equal(inputTrip.days && inputTrip.days[0].itinerary[1].placeId);
@@ -67,7 +67,7 @@ describe('TripManipulator', () => {
 				} as Day);
 			}
 
-			return chai.expect(Manipulator.prependDayToTrip(inputTrip)).to.deep.equal(expectedTrip);
+			return chai.expect(Manipulator.prependDayToTrip(inputTrip, null)).to.deep.equal(expectedTrip);
 		});
 
 		it('should add day to trip and add sticky place by default to new day', () => {
@@ -79,7 +79,7 @@ describe('TripManipulator', () => {
 					place.categories = ['sleeping'];
 				}
 			}
-			const returnedTrip = Manipulator.prependDayToTrip(inputTrip);
+			const returnedTrip = Manipulator.prependDayToTrip(inputTrip, null);
 
 			return chai.expect(returnedTrip.days && returnedTrip.days[0].itinerary[0].placeId)
 				.to.equal(inputTrip.days && inputTrip.days[0].itinerary[0].placeId);
@@ -90,7 +90,7 @@ describe('TripManipulator', () => {
 		it('should throw an error when invalid index is passed', () => {
 			const indexToBeRemoved = 999;
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
-			return chai.expect(() => Manipulator.removeDayFromTrip(inputTrip, indexToBeRemoved))
+			return chai.expect(() => Manipulator.removeDayFromTrip(inputTrip, indexToBeRemoved, null))
 				.to.throw(Error, 'Invalid dayIndex');
 		});
 
@@ -106,7 +106,7 @@ describe('TripManipulator', () => {
 				expectedTrip.days[0].itinerary[1].isSticky = false;
 			}
 
-			return chai.expect(Manipulator.removeDayFromTrip(inputTrip, indexToBeRemoved)).to.deep.equal(expectedTrip);
+			return chai.expect(Manipulator.removeDayFromTrip(inputTrip, indexToBeRemoved, null)).to.deep.equal(expectedTrip);
 		});
 
 		it('should remove day from beginning of days array and should change start date', () => {
@@ -121,7 +121,7 @@ describe('TripManipulator', () => {
 				expectedTrip.days[0].itinerary[0].isSticky = false;
 			}
 
-			return chai.expect(Manipulator.removeDayFromTrip(inputTrip, indexToBeRemoved)).to.deep.equal(expectedTrip);
+			return chai.expect(Manipulator.removeDayFromTrip(inputTrip, indexToBeRemoved, null)).to.deep.equal(expectedTrip);
 		});
 
 		it('should remove day from end of days array and should change end date', () => {
@@ -135,19 +135,21 @@ describe('TripManipulator', () => {
 				expectedTrip.days.pop();
 			}
 
-			return chai.expect(Manipulator.removeDayFromTrip(inputTrip, indexToBeRemoved)).to.deep.equal(expectedTrip);
+			return chai.expect(Manipulator.removeDayFromTrip(inputTrip, indexToBeRemoved, null)).to.deep.equal(expectedTrip);
 		});
 	});
 
 	describe('#swapDaysInTrip', () => {
 		it('should throw an error when invalid firstDayIndex is passed', () => {
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
-			return chai.expect(() => Manipulator.swapDaysInTrip(inputTrip, 999, 1)).to.throw(Error, 'Invalid firstDayIndex');
+			return chai.expect(() => Manipulator.swapDaysInTrip(inputTrip, 999, 1, null))
+				.to.throw(Error, 'Invalid firstDayIndex');
 		});
 
 		it('should throw an error when invalid secondDayIndex is passed', () => {
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
-			return chai.expect(() => Manipulator.swapDaysInTrip(inputTrip, 0, 999)).to.throw(Error, 'Invalid secondDayIndex');
+			return chai.expect(() => Manipulator.swapDaysInTrip(inputTrip, 0, 999, null))
+				.to.throw(Error, 'Invalid secondDayIndex');
 		});
 
 		it('should swap two days', () => {
@@ -162,26 +164,26 @@ describe('TripManipulator', () => {
 				expectedTrip.days[1].itinerary[1].isSticky = false;
 			}
 
-			return chai.expect(Manipulator.swapDaysInTrip(inputTrip, 0, 1)).to.deep.equal(expectedTrip);
+			return chai.expect(Manipulator.swapDaysInTrip(inputTrip, 0, 1, null)).to.deep.equal(expectedTrip);
 		});
 	});
 
 	describe('#movePlaceInDay', () => {
 		it('should throw an error when invalid dayIndex is passed', () => {
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
-			return chai.expect(() => Manipulator.movePlaceInDay(inputTrip, 999, 0, 1))
+			return chai.expect(() => Manipulator.movePlaceInDay(inputTrip, 999, 0, 1, null))
 				.to.throw(Error, 'Invalid dayIndex');
 		});
 
 		it('should throw an error when invalid positionFrom is passed', () => {
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
-			return chai.expect(() => Manipulator.movePlaceInDay(inputTrip, 0, 999, 1))
+			return chai.expect(() => Manipulator.movePlaceInDay(inputTrip, 0, 999, 1, null))
 				.to.throw(Error, 'Invalid positionFrom');
 		});
 
 		it('should throw an error when invalid positionTo is passed', () => {
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
-			return chai.expect(() => Manipulator.movePlaceInDay(inputTrip, 0, 0, 999))
+			return chai.expect(() => Manipulator.movePlaceInDay(inputTrip, 0, 0, 999, null))
 				.to.throw(Error, 'Invalid positionTo');
 		});
 
@@ -208,7 +210,7 @@ describe('TripManipulator', () => {
 				expectedTrip.days[0].itinerary[3] = buildTestItem('poi:2');
 			}
 
-			return chai.expect(Manipulator.movePlaceInDay(inputTrip, 0, positionFrom, positionTo))
+			return chai.expect(Manipulator.movePlaceInDay(inputTrip, 0, positionFrom, positionTo, null))
 				.to.deep.equal(expectedTrip);
 		});
 
@@ -235,7 +237,7 @@ describe('TripManipulator', () => {
 				expectedTrip.days[0].itinerary[3] = buildTestItem('poi:3');
 			}
 
-			return chai.expect(Manipulator.movePlaceInDay(inputTrip, 0, positionFrom, positionTo))
+			return chai.expect(Manipulator.movePlaceInDay(inputTrip, 0, positionFrom, positionTo, null))
 				.to.deep.equal(expectedTrip);
 		});
 	});
@@ -243,13 +245,13 @@ describe('TripManipulator', () => {
 	describe('#removePlacesFromDay', () => {
 		it('should throw error when invalid dayIndex is passed', () => {
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
-			return chai.expect(() => Manipulator.removePlacesFromDay(inputTrip, 999, [0]))
+			return chai.expect(() => Manipulator.removePlacesFromDay(inputTrip, 999, [0], null))
 				.to.throw(Error, 'Invalid dayIndex');
 		});
 
 		it('should throw error when invalid positionInDay is passed', () => {
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
-			return chai.expect(() => Manipulator.removePlacesFromDay(inputTrip, 0, [99]))
+			return chai.expect(() => Manipulator.removePlacesFromDay(inputTrip, 0, [99], null))
 				.to.throw(Error, 'Invalid positionInDay');
 		});
 
@@ -262,7 +264,7 @@ describe('TripManipulator', () => {
 				expectedTrip.days[0].itinerary.splice(positionInDay, 1);
 			}
 
-			const result = Manipulator.removePlacesFromDay(inputTrip, 0, [positionInDay]);
+			const result = Manipulator.removePlacesFromDay(inputTrip, 0, [positionInDay], null);
 			return chai.expect(result).to.deep.equal(expectedTrip);
 		});
 
@@ -275,7 +277,7 @@ describe('TripManipulator', () => {
 				expectedTrip.days[1].itinerary[0].isSticky = false;
 			}
 
-			const result = Manipulator.removePlacesFromDay(inputTrip, 0, [0, 1]);
+			const result = Manipulator.removePlacesFromDay(inputTrip, 0, [0, 1], null);
 			return chai.expect(result).to.deep.equal(expectedTrip);
 		});
 	});
@@ -285,7 +287,7 @@ describe('TripManipulator', () => {
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
 			const inputPlace: Place = cloneDeep(PlaceExpectedResults.placeDetailedEiffelTowerWithoutMedia);
 
-			return chai.expect(() => Manipulator.addPlaceToDay(inputTrip, inputPlace, 999))
+			return chai.expect(() => Manipulator.addPlaceToDay(inputTrip, inputPlace, 999, null))
 				.to.throw(Error, 'Invalid dayIndex');
 		});
 
@@ -293,7 +295,7 @@ describe('TripManipulator', () => {
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
 			const inputPlace: Place = cloneDeep(PlaceExpectedResults.placeDetailedEiffelTowerWithoutMedia);
 
-			return chai.expect(() => Manipulator.addPlaceToDay(inputTrip, inputPlace, 0, 999))
+			return chai.expect(() => Manipulator.addPlaceToDay(inputTrip, inputPlace, 0, null, 999))
 				.to.throw(Error, 'Invalid positionInDay');
 		});
 
@@ -316,7 +318,7 @@ describe('TripManipulator', () => {
 				expectedTrip.days[1].itinerary[0].isSticky = false;
 			}
 
-			return chai.expect(Manipulator.addPlaceToDay(inputTrip, inputPlace, 0)).to.deep.equal(expectedTrip);
+			return chai.expect(Manipulator.addPlaceToDay(inputTrip, inputPlace, 0, null)).to.deep.equal(expectedTrip);
 		});
 
 		it('should correctly add place to to right position in day when positionInDay is set', () => {
@@ -338,7 +340,7 @@ describe('TripManipulator', () => {
 				} as ItineraryItem);
 			}
 
-			return chai.expect(Manipulator.addPlaceToDay(inputTrip, inputPlace, 0, positionInDay))
+			return chai.expect(Manipulator.addPlaceToDay(inputTrip, inputPlace, 0, null, positionInDay))
 				.to.deep.equal(expectedTrip);
 		});
 	});
@@ -390,7 +392,7 @@ describe('TripManipulator', () => {
 			const inputTrip: Trip = cloneDeep(TripExpectedResults.tripDetailed);
 			const inputPlace: Place = cloneDeep(PlaceExpectedResults.placeDetailedEiffelTowerWithoutMedia);
 
-			return chai.expect(() => Manipulator.replaceStickyPlace(inputTrip, inputPlace, 999))
+			return chai.expect(() => Manipulator.replaceStickyPlace(inputTrip, inputPlace, 999, null))
 				.to.throw(Error, 'Invalid dayIndex');
 		});
 
@@ -412,7 +414,7 @@ describe('TripManipulator', () => {
 				expectedTrip.days[0].itinerary[1] = item;
 				expectedTrip.days[1].itinerary[0] = item;
 			}
-			const trip = Manipulator.replaceStickyPlace(inputTrip, inputPlace, 0);
+			const trip = Manipulator.replaceStickyPlace(inputTrip, inputPlace, 0, null);
 			return chai.expect(trip).to.deep.equal(expectedTrip);
 		});
 	});

--- a/src/Trip/Mapper.test.ts
+++ b/src/Trip/Mapper.test.ts
@@ -5,6 +5,7 @@ import * as cloneDeep from 'lodash.clonedeep';
 import * as ApiResponses from '../TestData/TripApiResponses';
 import * as ExpectedResults from '../TestData/TripExpectedResults';
 import * as Mapper from '../Trip/Mapper';
+import { UserSettings } from '../User';
 
 chai.use(chaiAsPromised);
 
@@ -19,7 +20,7 @@ describe('TripMapper', () => {
 	describe('#mapTripToApiFormat', () => {
 		it('should correctly map trip to api response', () => {
 			const expectedResponse = ApiResponses.tripDetail.trip;
-			const trip = Mapper.mapTripDetailedApiResponseToTrip(ApiResponses.tripDetail.trip);
+			const trip = Mapper.mapTripDetailedApiResponseToTrip(ApiResponses.tripDetail.trip, null);
 			const mappedResponse = Mapper.mapTripToApiFormat(trip);
 			return chai.expect(mappedResponse).to.deep.equal(expectedResponse);
 		});
@@ -33,7 +34,71 @@ describe('TripMapper', () => {
 					delete item.place;
 				});
 			});
-			chai.expect(Mapper.mapTripDetailedApiResponseToTrip(ApiResponses.tripDetail.trip))
+			chai.expect(Mapper.mapTripDetailedApiResponseToTrip(ApiResponses.tripDetail.trip, null))
+				.to.deep.equal(result);
+		});
+
+		it('should correctly map api response and set home stickiness in first day', () => {
+			const result = cloneDeep(ExpectedResults.tripDetailed);
+			result.days.forEach((day) => {
+				day.itinerary.forEach((item) => {
+					delete item.place;
+				});
+			});
+			result.days[0].itinerary[0].isSticky = true;
+			const userSettings: UserSettings = {
+				homePlaceId: 'poi:1',
+				workPlaceId: null
+			};
+			chai.expect(Mapper.mapTripDetailedApiResponseToTrip(ApiResponses.tripDetail.trip, userSettings))
+				.to.deep.equal(result);
+		});
+
+		it('should correctly map api response and set work stickiness in first day', () => {
+			const result = cloneDeep(ExpectedResults.tripDetailed);
+			result.days.forEach((day) => {
+				day.itinerary.forEach((item) => {
+					delete item.place;
+				});
+			});
+			result.days[0].itinerary[0].isSticky = true;
+			const userSettings: UserSettings = {
+				homePlaceId: 'poi:10',
+				workPlaceId: 'poi:1'
+			};
+			chai.expect(Mapper.mapTripDetailedApiResponseToTrip(ApiResponses.tripDetail.trip, userSettings))
+				.to.deep.equal(result);
+		});
+
+		it('should correctly map api response and set home stickiness in last day', () => {
+			const result = cloneDeep(ExpectedResults.tripDetailed);
+			result.days.forEach((day) => {
+				day.itinerary.forEach((item) => {
+					delete item.place;
+				});
+			});
+			result.days[2].itinerary[0].isSticky = true;
+			const userSettings: UserSettings = {
+				homePlaceId: 'poi:4',
+				workPlaceId: 'poi:10'
+			};
+			chai.expect(Mapper.mapTripDetailedApiResponseToTrip(ApiResponses.tripDetail.trip, userSettings))
+				.to.deep.equal(result);
+		});
+
+		it('should correctly map api response and set work stickiness in last day', () => {
+			const result = cloneDeep(ExpectedResults.tripDetailed);
+			result.days.forEach((day) => {
+				day.itinerary.forEach((item) => {
+					delete item.place;
+				});
+			});
+			result.days[2].itinerary[0].isSticky = true;
+			const userSettings: UserSettings = {
+				homePlaceId: 'poi:10',
+				workPlaceId: 'poi:4'
+			};
+			chai.expect(Mapper.mapTripDetailedApiResponseToTrip(ApiResponses.tripDetail.trip, userSettings))
 				.to.deep.equal(result);
 		});
 	});

--- a/src/Trip/PositionFinder.test.ts
+++ b/src/Trip/PositionFinder.test.ts
@@ -10,11 +10,11 @@ import { ItineraryItem } from './Trip';
 describe('PositionFinder', () => {
 	describe('#findOptimalPosition', () => {
 		it('should find ok position for empty day', () => {
-			chai.expect(findOptimalPosition(place, [])).to.equal(0);
+			chai.expect(findOptimalPosition(place, [], null)).to.equal(0);
 		});
 
 		it('should add as second place when one place is present', () => {
-			chai.expect(findOptimalPosition(buildTestPlace(0, 0, 'p:1'), [buildTestItem(0, 1, 'p:2', false)])).to.equal(1);
+			chai.expect(findOptimalPosition(buildTestPlace(0, 0, 'p:1'), [buildTestItem(0, 1, 'p:2', false)], null)).to.equal(1);
 		});
 
 		it('should add at correct place by air distance ', () => {
@@ -24,7 +24,7 @@ describe('PositionFinder', () => {
 				buildTestItem(0, 2, 'p:2', false),
 				buildTestItem(0, 3, 'p:3', false),
 			];
-			chai.expect(findOptimalPosition(placeIn, places)).to.equal(1);
+			chai.expect(findOptimalPosition(placeIn, places, null)).to.equal(1);
 		});
 
 		it('should add at correct place by air distance and respect sticky at beginning', () => {
@@ -34,7 +34,7 @@ describe('PositionFinder', () => {
 				buildTestItem(0, 2, 'p:2', false),
 				buildTestItem(0, 3, 'p:3', false),
 			];
-			chai.expect(findOptimalPosition(placeIn, places)).to.equal(1);
+			chai.expect(findOptimalPosition(placeIn, places, null)).to.equal(1);
 		});
 
 		it('should add at correct place by air distance and respect sticky at the and', () => {
@@ -44,7 +44,7 @@ describe('PositionFinder', () => {
 				buildTestItem(0, 2, 'p:2', false),
 				buildTestItem(0, 3, 'p:3', true),
 			];
-			chai.expect(findOptimalPosition(placeIn, places)).to.equal(2);
+			chai.expect(findOptimalPosition(placeIn, places, null)).to.equal(2);
 		});
 
 		it('should add by default sticky place as last', () => {
@@ -54,7 +54,7 @@ describe('PositionFinder', () => {
 				buildTestItem(0, 1, 'p:0', false),
 				buildTestItem(0, 3, 'p:1', false),
 			];
-			chai.expect(findOptimalPosition(placeIn, places)).to.equal(2);
+			chai.expect(findOptimalPosition(placeIn, places, null)).to.equal(2);
 		});
 
 		it('should add by default sticky place to order when other sticky is present', () => {
@@ -65,7 +65,43 @@ describe('PositionFinder', () => {
 				buildTestItem(0, 2, 'p:2', false),
 				buildTestItem(0, 3, 'p:3', true),
 			];
-			chai.expect(findOptimalPosition(placeIn, places)).to.equal(0);
+			chai.expect(findOptimalPosition(placeIn, places, null)).to.equal(0);
+		});
+
+		it('should add to second position if only place is sticky and next day is empty', () => {
+			const placeIn = buildTestPlace(0, 0, 'p:2');
+			placeIn.categories = ['sleeping'];
+			const places = [
+				buildTestItem(0, 1, 'p:0', true),
+			];
+			chai.expect(findOptimalPosition(placeIn, places, [])).to.equal(1);
+		});
+
+		it('should add to second position if only place is sticky and next begins with other item', () => {
+			const placeIn = buildTestPlace(0, 0, 'p:2');
+			placeIn.categories = ['sleeping'];
+			const places = [
+				buildTestItem(0, 1, 'p:0', true),
+			];
+			chai.expect(findOptimalPosition(placeIn, places, [buildTestItem(0, 1, 'p:1', true)])).to.equal(1);
+		});
+
+		it('should add to first position if only place is sticky and next begins with same item', () => {
+			const placeIn = buildTestPlace(0, 0, 'p:2');
+			placeIn.categories = ['sleeping'];
+			const places = [
+				buildTestItem(0, 1, 'p:0', true),
+			];
+			chai.expect(findOptimalPosition(placeIn, places, [buildTestItem(0, 1, 'p:0', true)])).to.equal(0);
+		});
+
+		it('should add to first position if only place is sticky and next day does not exists', () => {
+			const placeIn = buildTestPlace(0, 0, 'p:2');
+			placeIn.categories = ['sleeping'];
+			const places = [
+				buildTestItem(0, 1, 'p:0', true),
+			];
+			chai.expect(findOptimalPosition(placeIn, places, null)).to.equal(0);
 		});
 	});
 });

--- a/src/Trip/PositionFinder.ts
+++ b/src/Trip/PositionFinder.ts
@@ -4,11 +4,21 @@ import { isStickyByDefault, Place } from '../Places';
 
 export function findOptimalPosition(
 	place: Place,
-	itineraryItems: ItineraryItem[]
+	itinerary: ItineraryItem[],
+	nextItinerary: ItineraryItem[] | null,
 ): number {
 
-	if (isStickyByDefault(place) && (!itineraryItems.length || !itineraryItems[itineraryItems.length - 1].isSticky)) {
-		return itineraryItems.length;
+	if (isStickyByDefault(place) && (!itinerary.length || !itinerary[itinerary.length - 1].isSticky)) {
+		return itinerary.length;
+	}
+
+	if (
+		itinerary.length === 1 &&
+		itinerary[0].isSticky &&
+		nextItinerary &&
+		(nextItinerary.length === 0 || nextItinerary[0].placeId !== itinerary[0].placeId)
+	) {
+		return 1;
 	}
 
 	let minDistance = 0;
@@ -16,23 +26,23 @@ export function findOptimalPosition(
 	let checkIndex = 0;
 	const blockedIndexes: number[] = [];
 
-	if (itineraryItems.find((item: ItineraryItem) => (item.place === null))) {
+	if (itinerary.find((item: ItineraryItem) => (item.place === null))) {
 		throw new Error('Itinerary item place is not filled');
 	}
 
-	const locations: Location[] = itineraryItems.reduce((locs: Location[], item: ItineraryItem): Location[] => {
+	const locations: Location[] = itinerary.reduce((locs: Location[], item: ItineraryItem): Location[] => {
 		if (item.place) {
 			locs.push(item.place.location);
 		}
 		return locs;
 	}, []);
 
-	if (itineraryItems[0] && itineraryItems[0].isSticky) {
+	if (itinerary[0] && itinerary[0].isSticky) {
 		blockedIndexes.push(0);
 	}
 
-	if (itineraryItems.length && itineraryItems[itineraryItems.length - 1].isSticky) {
-		blockedIndexes.push(itineraryItems.length);
+	if (itinerary.length && itinerary[itinerary.length - 1].isSticky) {
+		blockedIndexes.push(itinerary.length);
 	}
 
 	while (checkIndex <= locations.length) {

--- a/src/Trip/index.test.ts
+++ b/src/Trip/index.test.ts
@@ -10,6 +10,7 @@ import { setEnvironment } from '../Settings';
 import * as PlaceTestData from '../TestData/PlacesApiResponses';
 import * as TripTestData from '../TestData/TripApiResponses';
 import * as TripExpectedResults from '../TestData/TripExpectedResults';
+import * as User from '../User';
 import * as Xhr from '../Xhr';
 import { ApiResponse } from '../Xhr/ApiResponse';
 
@@ -24,6 +25,9 @@ describe('TripController', () => {
 
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
+		sandbox.stub(User, 'getUserSettings').returns(new Promise<User.UserSettings>((resolve) => {
+			resolve({homePlaceId: null, workPlaceId: null});
+		}));
 		tripsDetailedCache.reset();
 	});
 

--- a/src/Trip/index.ts
+++ b/src/Trip/index.ts
@@ -1,5 +1,6 @@
 import { ChangeNotification } from '../Changes';
 import { Dao as placesDao, getPlaceDetailed, getPlacesDetailed, isStickyByDefault, Place } from '../Places';
+import { getUserSettings } from '../User';
 import { addDaysToDate } from '../Util/index';
 import * as Dao from './DataAccess';
 import * as TripManipulator from './Manipulator';
@@ -106,7 +107,7 @@ export async function updateTrip(id: string, dataToUpdate: TripUpdateData): Prom
 export async function addDaysToTrip(id: string, count: number): Promise<Trip> {
 	let tripToBeUpdated = await getTripDetailed(id);
 	for (let i = 0; i < count; i++) {
-		tripToBeUpdated = TripManipulator.addDay(tripToBeUpdated);
+		tripToBeUpdated = TripManipulator.addDay(tripToBeUpdated, await getUserSettings());
 	}
 	return Dao.updateTrip(tripToBeUpdated);
 }
@@ -114,17 +115,22 @@ export async function addDaysToTrip(id: string, count: number): Promise<Trip> {
 export async function prependDaysToTrip(id: string, count: number): Promise<Trip> {
 	let tripToBeUpdated = await getTripDetailed(id);
 	for (let i = 0; i < count; i++) {
-		tripToBeUpdated = TripManipulator.prependDayToTrip(tripToBeUpdated);
+		tripToBeUpdated = TripManipulator.prependDayToTrip(tripToBeUpdated, await getUserSettings());
 	}
 	return Dao.updateTrip(tripToBeUpdated);
 }
 
 export async function removeDayFromTrip(id: string, dayIndex: number): Promise<Trip> {
-	return Dao.updateTrip(TripManipulator.removeDayFromTrip(await getTripDetailed(id), dayIndex));
+	return Dao.updateTrip(TripManipulator.removeDayFromTrip(await getTripDetailed(id), dayIndex, await getUserSettings()));
 }
 
 export async function swapDaysInTrip(id: string, firstDayIndex: number, secondDayIndex: number): Promise<Trip>  {
-	return Dao.updateTrip(TripManipulator.swapDaysInTrip(await getTripDetailed(id), firstDayIndex, secondDayIndex));
+	return Dao.updateTrip(TripManipulator.swapDaysInTrip(
+		await getTripDetailed(id),
+		firstDayIndex,
+		secondDayIndex,
+		await getUserSettings()
+	));
 }
 
 export async function setTransport(
@@ -140,11 +146,19 @@ export async function movePlaceInDay(
 	dayIndex: number,
 	positionFrom: number,
 	positionTo: number): Promise<Trip> {
-	return Dao.updateTrip(TripManipulator.movePlaceInDay(await getTripDetailed(id), dayIndex, positionFrom, positionTo));
+	return Dao.updateTrip(TripManipulator.movePlaceInDay(
+		await getTripDetailed(id),
+		dayIndex,
+		positionFrom,
+		positionTo,
+		await getUserSettings())
+	);
 }
 
 export async function removePlacesFromDay(id: string, dayIndex: number, positionsInDay: number[]): Promise<Trip> {
-	return Dao.updateTrip(TripManipulator.removePlacesFromDay(await getTripDetailed(id), dayIndex, positionsInDay));
+	return Dao.updateTrip(
+		TripManipulator.removePlacesFromDay(await getTripDetailed(id), dayIndex, positionsInDay, await getUserSettings())
+	);
 }
 
 /**
@@ -168,11 +182,11 @@ export async function addPlaceToDay(
 	}
 
 	if (typeof positionInDay !== 'undefined' && positionInDay !== null) {
-		return Dao.updateTrip(TripManipulator.addPlaceToDay(trip, place, dayIndex, positionInDay));
+		return Dao.updateTrip(TripManipulator.addPlaceToDay(trip, place, dayIndex, await getUserSettings(), positionInDay));
 	}
 
 	if (replaceSticky) {
-		return Dao.updateTrip(TripManipulator.replaceStickyPlace(trip, place, dayIndex));
+		return Dao.updateTrip(TripManipulator.replaceStickyPlace(trip, place, dayIndex, await getUserSettings()));
 	}
 
 	let dayItems: ItineraryItem[] = [];
@@ -195,14 +209,14 @@ export async function addPlaceToDay(
 		dayItems,
 		nextDayItinerary
 	);
-	trip = TripManipulator.addPlaceToDay(trip, place, dayIndex, positionInDay);
+	trip = TripManipulator.addPlaceToDay(trip, place, dayIndex, await getUserSettings(), positionInDay);
 
 	if (
 		(isStickyByDefault(place)) &&
 		nextDayItinerary &&
 		(!nextDayItinerary.length || !nextDayItinerary[0].isSticky)
 	) {
-		trip = TripManipulator.addPlaceToDay(trip, place, nextDayIndex, 0);
+		trip = TripManipulator.addPlaceToDay(trip, place, nextDayIndex, await getUserSettings(), 0);
 	}
 	return Dao.updateTrip(trip);
 }

--- a/src/Trip/index.ts
+++ b/src/Trip/index.ts
@@ -182,18 +182,25 @@ export async function addPlaceToDay(
 		dayItems = trip.days[dayIndex].itinerary;
 	}
 
+	const nextDayIndex = dayIndex + 1;
+	let nextDayItinerary: ItineraryItem[] | null = null;
+	if (trip.days &&
+		trip.days[nextDayIndex]
+	) {
+		nextDayItinerary = trip.days[nextDayIndex].itinerary;
+	}
+
 	positionInDay = PositionFinder.findOptimalPosition(
 		place,
-		dayItems
+		dayItems,
+		nextDayItinerary
 	);
 	trip = TripManipulator.addPlaceToDay(trip, place, dayIndex, positionInDay);
-	const nextDayIndex = dayIndex + 1;
 
 	if (
 		(isStickyByDefault(place)) &&
-		trip.days &&
-		trip.days[nextDayIndex] &&
-		(!trip.days[nextDayIndex].itinerary.length || !trip.days[nextDayIndex].itinerary[0].isSticky)
+		nextDayItinerary &&
+		(!nextDayItinerary.length || !nextDayItinerary[0].isSticky)
 	) {
 		trip = TripManipulator.addPlaceToDay(trip, place, nextDayIndex, 0);
 	}


### PR DESCRIPTION
Home and work behave as sticky places. I'm not sure about architecture design. To be able to correctly decorate sticky places (which is done in mapper and then every time when trip changes in trip manipulator) we have to pass userSettings to correctly detect home and work stickiness.
I see two different approaches:

1) load user data within stickiness decorator, but this would make it async and then all the methods within manipulator an mapper would be async, which I find worse solution then passing userData as argument
2) Like 1) but also remove stickiness decoration from mapper and  trip manipulator and call async stickiness decoration in all places where it is needed. Minus is that we must not forget to do it :(
3) This solution which means a quite a lot arguments passing but I still find it as the best one...